### PR TITLE
Fix pre-existing CI test failures (frontend + backend)

### DIFF
--- a/Backend/tests/test_startup_lifespan.py
+++ b/Backend/tests/test_startup_lifespan.py
@@ -6,6 +6,12 @@ from app.main import lifespan
 
 @pytest.mark.asyncio
 async def test_lifespan_continues_when_startup_checks_fail(monkeypatch):
+    """A failure in the background startup health checks must not crash the app.
+
+    The lifespan starts the scheduler immediately and runs the DB health checks
+    in a background task, so a check failure is swallowed and the app keeps
+    serving. The scheduler still starts on entry and is stopped on shutdown.
+    """
     started = False
     stopped = False
 
@@ -24,8 +30,12 @@ async def test_lifespan_continues_when_startup_checks_fail(monkeypatch):
     monkeypatch.setattr("app.main.start_scheduler", fake_start_scheduler)
     monkeypatch.setattr("app.main.stop_scheduler", fake_stop_scheduler)
 
+    # Entering and exiting the lifespan must not raise even though the
+    # background health checks fail.
     async with lifespan(FastAPI()):
         pass
 
-    assert started is False
-    assert stopped is False
+    # Scheduler starts immediately (independent of the DB checks) and is
+    # stopped cleanly on shutdown.
+    assert started is True
+    assert stopped is True

--- a/Frontend/src/features/recommendation/services/__tests__/recommendationApi.test.ts
+++ b/Frontend/src/features/recommendation/services/__tests__/recommendationApi.test.ts
@@ -86,6 +86,7 @@ describe("getRecommendations", () => {
         user_lat: 44.974,
         user_lon: -93.228,
         limit: 5,
+        travel_mode: "walking",
         verified_only: true,
       },
     })

--- a/Frontend/src/lib/api/client.ts
+++ b/Frontend/src/lib/api/client.ts
@@ -6,13 +6,18 @@ import { useAuthStore } from "@/store/authStore"
 const apiUrl = import.meta.env.VITE_API_URL
 const resolvedApiUrl = apiUrl?.trim()
 
-// This is a sanity check to prevent accidentally building a production bundle without setting VITE_API_URL
-if (!resolvedApiUrl) {
+// Guard production builds against a missing API URL. In dev and test (vitest)
+// we fall back to localhost so the app and the test suite can boot without a
+// .env file present.
+if (import.meta.env.PROD && !resolvedApiUrl) {
   throw new Error("VITE_API_URL is not set. Configure it before building for production.")
 }
+
+const baseURL = resolvedApiUrl || "http://localhost:8000/api"
+
 // This client instance is used for all API calls. Interceptors handle token attachment and refresh.
 const client = axios.create({
-  baseURL: resolvedApiUrl,
+  baseURL,
   timeout: 20000,
   headers: {
     "Content-Type": "application/json",
@@ -45,7 +50,7 @@ client.interceptors.response.use(
       if (refreshToken) {
         try {
           const res = await axios.post(
-            `${resolvedApiUrl}/auth/refresh`,
+            `${baseURL}/auth/refresh`,
             { refresh_token: refreshToken }
           )
           localStorage.setItem("access_token", res.data.access_token)


### PR DESCRIPTION
## Why
The `Backend Tests`, `Frontend Tests`, and `Create Neon Branch` checks were failing on PR #18, but **none of those failures came from that PR**. The CI test jobs only run on pull requests; pushes to `main` only run the `Deploy` workflow. So this latent breakage in `main` was never gated, and #18 was simply the first PR to surface it.

This PR fixes the code/test bugs so CI can go green again.

## Fixes

### 1. `client.ts` threw on import in CI (broke the whole frontend suite)
`Frontend/src/lib/api/client.ts` threw `"VITE_API_URL is not set"` at import time whenever the env var was unset. CI runs `npx vitest run` with no `.env` (it is gitignored), so every test importing the API client crashed on import. The guard's own comment says it exists to catch *production builds* - so it is now gated on `import.meta.env.PROD`, with a localhost fallback in dev/test. Production builds still fail loudly if `VITE_API_URL` is missing.

### 2. Stale frontend test: `recommendationApi.test.ts`
`getRecommendations` always sends `travel_mode: "walking"`, but the "passes query params" test still expected params without it. Updated the expected params to match the source.

### 3. Stale backend test: `test_startup_lifespan.py`
`app.main.lifespan` was refactored to start the scheduler immediately and run DB health checks in a background task that swallows failures (so the app serves requests without waiting on the DB). The test still asserted the old contract (`started is False` when checks fail). Updated it to assert the current contract: the lifespan does not crash on a check failure, and the scheduler starts on entry and stops cleanly on shutdown.

## Not fixed here (infra)
`Create Neon Branch` fails with `AxiosError: 401`, i.e. an expired/invalid `NEON_API_KEY` repo secret. That needs a secret rotation, not a code change. The `Backend Tests` job uses `if: always()` and runs against `TEST_DATABASE_URL` regardless, so it can still pass with Neon down.

## Validation
- Frontend: `npx vitest run` -> 160 passed, 1 skipped. Re-ran the previously-failing files with all `.env*` moved aside (simulating CI) -> pass.
- Frontend: `npm run build` succeeds (PROD guard intact via `.env.production`).
- Backend: `pytest -q` -> 78 passed, 5 skipped.
- Changed frontend files lint-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)