### PR TITLE
Add useRef for persistent routing in RouteLayer component #15

### DIFF
--- a/Frontend/src/features/map/components/RouteLayer.tsx
+++ b/Frontend/src/features/map/components/RouteLayer.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import maplibregl from "maplibre-gl";
 import { useNavStore } from "../../../store/navStore";
 import { snapToRoute } from "../../navigation/components/services/routingApi";
@@ -77,6 +77,7 @@ function findClosestProjectedPoint(
 
 export default function RouteLayer({ map, userLocation }: RouteLayerProps) {
   const { isNavigating, destination, route, routeStatus, travelMode } = useNavStore();
+  const applyRouteRef = useRef<(() => void) | null>(null);
 
   useEffect(() => {
     if (!map) return;
@@ -89,6 +90,7 @@ export default function RouteLayer({ map, userLocation }: RouteLayerProps) {
       destination.longitude == null ||
       destination.latitude == null
     ) {
+      applyRouteRef.current = null;
       removeRouteLayer(map);
       return;
     }
@@ -149,12 +151,21 @@ export default function RouteLayer({ map, userLocation }: RouteLayerProps) {
       }
     };
 
+    applyRouteRef.current = applyRoute;
+
     if (map.isStyleLoaded()) {
       applyRoute();
-    } else {
-      map.once("load", applyRoute);
     }
   }, [destination, isNavigating, map, route, routeStatus, travelMode, userLocation]);
+
+  // Persistent listener covers both the initial style load and every setStyle() call.
+  // Calling applyRouteRef.current is a no-op when navigation is inactive (ref is null).
+  useEffect(() => {
+    if (!map) return;
+    const onStyleLoad = () => applyRouteRef.current?.();
+    map.on("style.load", onStyleLoad);
+    return () => { map.off("style.load", onStyleLoad); };
+  }, [map]);
 
   useEffect(() => {
     return () => {

--- a/Frontend/src/features/map/components/__tests__/RouteLayer.test.tsx
+++ b/Frontend/src/features/map/components/__tests__/RouteLayer.test.tsx
@@ -78,6 +78,8 @@ function makeMockMap(hasExistingSource = false) {
     removeLayer: vi.fn(),
     removeSource: vi.fn(),
     once: vi.fn(),
+    on: vi.fn(),
+    off: vi.fn(),
   } as unknown as import('maplibre-gl').Map
 
   return { map, setData, addSource, addLayer }


### PR DESCRIPTION
This pull request improves the handling of route rendering in the `RouteLayer` component to ensure the route layer is consistently reapplied whenever the map style changes (including after `setStyle()` calls), and cleans up event listeners properly. The approach uses a persistent ref and a single event listener for robust and efficient route updates.

**Route rendering reliability and event handling:**

* Introduced a `useRef` (`applyRouteRef`) to persist the current route application function across renders, ensuring the latest logic is always available to event listeners. [[1]](diffhunk://#diff-704f42e6fa70aaa16aa72b31238e3adfedf82dae4c22ba13fc3a907e65055f70L1-R1) [[2]](diffhunk://#diff-704f42e6fa70aaa16aa72b31238e3adfedf82dae4c22ba13fc3a907e65055f70R80)
* Updated the logic so that when navigation is inactive or the destination is invalid, the route layer is removed and the ref is cleared, preventing unnecessary route rendering.
* Assigned the latest `applyRoute` function to the ref and removed the previous single-use `"load"` event handler in favor of a more robust solution.
* Added a persistent `"style.load"` event listener that always calls the latest `applyRoute` via the ref, ensuring the route layer is reapplied after any map style changes. The listener is properly cleaned up on unmount or map changes.

Closes issue 15