### PR TITLE
fix: Native Google Sign-In for Android APK

### DIFF
--- a/Backend/app/api/auth.py
+++ b/Backend/app/api/auth.py
@@ -17,7 +17,8 @@ router = APIRouter(prefix="/auth", tags=["auth"])
 
 
 class GoogleLoginRequest(BaseModel):
-    access_token: str
+    access_token: str | None = None
+    id_token: str | None = None
 
 
 @router.post("/google", response_model=TokenResponse, status_code=201)
@@ -27,10 +28,15 @@ async def login_with_google(
     body: GoogleLoginRequest,
     db: AsyncSession = Depends(get_db),
 ):
-    """Exchange a Google OAuth access token for a Park&Go JWT.
+    """Exchange a Google OAuth token for a Park&Go JWT.
+    Accepts either an access_token (web GIS flow) or an id_token (native Android flow).
     Creates the user record on first login."""
     try:
-        result = await google_login(db, body.access_token)
+        result = await google_login(
+            db,
+            google_access_token=body.access_token,
+            google_id_token=body.id_token,
+        )
     except ValueError:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,

--- a/Backend/app/services/auth_service.py
+++ b/Backend/app/services/auth_service.py
@@ -6,6 +6,7 @@ from app.core.config import settings
 from app.core.security import create_access_token, create_refresh_token
 
 GOOGLE_USERINFO_URL = "https://www.googleapis.com/oauth2/v3/userinfo"
+GOOGLE_TOKENINFO_URL = "https://oauth2.googleapis.com/tokeninfo"
 
 
 async def verify_google_token(access_token: str) -> dict:
@@ -22,8 +23,36 @@ async def verify_google_token(access_token: str) -> dict:
     return response.json()
 
 
-async def google_login(db: AsyncSession, google_access_token: str) -> dict:
-    google_user = await verify_google_token(google_access_token)
+async def verify_google_id_token(id_token: str) -> dict:
+    """Verify a Google ID token (returned by native Android sign-in).
+
+    Uses the tokeninfo endpoint so we don't need the google-auth library.
+    The audience must match our web client ID so the token came from our app.
+    """
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            response = await client.get(GOOGLE_TOKENINFO_URL, params={"id_token": id_token})
+    except httpx.HTTPError as exc:
+        raise ValueError(f"Could not reach Google to verify ID token: {exc}") from exc
+    if response.status_code != 200:
+        raise ValueError("Invalid Google ID token")
+    data = response.json()
+    if data.get("aud") != settings.google_client_id:
+        raise ValueError("Token audience mismatch")
+    return data
+
+
+async def google_login(
+    db: AsyncSession,
+    google_access_token: str | None = None,
+    google_id_token: str | None = None,
+) -> dict:
+    if google_id_token:
+        google_user = await verify_google_id_token(google_id_token)
+    elif google_access_token:
+        google_user = await verify_google_token(google_access_token)
+    else:
+        raise ValueError("No Google token provided")
 
     google_id = google_user["sub"]
     email = google_user.get("email")

--- a/Frontend/capacitor.config.ts
+++ b/Frontend/capacitor.config.ts
@@ -20,6 +20,14 @@ const config: CapacitorConfig = {
       smallIcon: 'ic_stat_icon_config_sample',
       iconColor: '#7A0019',
     },
+    GoogleAuth: {
+      scopes: ['profile', 'email'],
+      // serverClientId is the Web OAuth client ID from Google Cloud Console.
+      // The value is set at runtime via GoogleAuth.initialize() using VITE_GOOGLE_CLIENT_ID.
+      // Fill this in as a static fallback after creating the Web OAuth client:
+      // serverClientId: 'YOUR_WEB_CLIENT_ID.apps.googleusercontent.com',
+      forceCodeForRefreshToken: false,
+    },
   },
 };
 

--- a/Frontend/package-lock.json
+++ b/Frontend/package-lock.json
@@ -11,6 +11,7 @@
         "@capacitor/android": "^8.2.0",
         "@capacitor/cli": "^8.2.0",
         "@capacitor/core": "^8.2.0",
+        "@codetrix-studio/capacitor-google-auth": "^3.4.0-rc.4",
         "@hookform/resolvers": "^5.2.2",
         "@mapbox/polyline": "^1.2.1",
         "@tanstack/react-query": "^5.90.21",
@@ -1771,6 +1772,15 @@
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@codetrix-studio/capacitor-google-auth": {
+      "version": "3.4.0-rc.4",
+      "resolved": "https://registry.npmjs.org/@codetrix-studio/capacitor-google-auth/-/capacitor-google-auth-3.4.0-rc.4.tgz",
+      "integrity": "sha512-d548/xKrbMHHbzMYSWnlgZCLZYo2zzY7Onrh3x8ujojrb7atkNK68I6su5WgmaBt4E+R4gxBsWams4554aOFjA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": "^6.0.0"
       }
     },
     "node_modules/@csstools/color-helpers": {
@@ -4209,27 +4219,6 @@
         "react": "^18 || ^19"
       }
     },
-    "node_modules/@testing-library/dom": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
-      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.10.4",
-        "@babel/runtime": "^7.12.5",
-        "@types/aria-query": "^5.0.1",
-        "aria-query": "5.3.0",
-        "dom-accessibility-api": "^0.5.9",
-        "lz-string": "^1.5.0",
-        "picocolors": "1.1.1",
-        "pretty-format": "^27.0.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.9.1",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
@@ -4314,14 +4303,6 @@
       "engines": {
         "node": ">=12"
       }
-    },
-    "node_modules/@types/aria-query": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
-      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -4440,7 +4421,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -5765,7 +5746,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/data-urls": {
@@ -6022,14 +6003,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/dom-accessibility-api": {
-      "version": "0.5.16",
-      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
-      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -8481,17 +8454,6 @@
         "yallist": "^3.0.2"
       }
     },
-    "node_modules/lz-string": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
-      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "bin": {
-        "lz-string": "bin/bin.js"
-      }
-    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -9176,36 +9138,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/pretty-format": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "ansi-regex": "^5.0.1",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^17.0.1"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
-    "node_modules/pretty-format/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -9304,14 +9236,6 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
-    },
-    "node_modules/react-is": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/react-map-gl": {
       "version": "8.1.0",

--- a/Frontend/package-lock.json
+++ b/Frontend/package-lock.json
@@ -4219,6 +4219,27 @@
         "react": "^18 || ^19"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.9.1",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
@@ -4303,6 +4324,14 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -4421,7 +4450,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -5746,7 +5775,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/data-urls": {
@@ -6003,6 +6032,14 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -8454,6 +8491,17 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -9138,6 +9186,36 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -9236,6 +9314,14 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-map-gl": {
       "version": "8.1.0",

--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -15,6 +15,7 @@
     "@capacitor/android": "^8.2.0",
     "@capacitor/cli": "^8.2.0",
     "@capacitor/core": "^8.2.0",
+    "@codetrix-studio/capacitor-google-auth": "^3.4.0-rc.4",
     "@hookform/resolvers": "^5.2.2",
     "@mapbox/polyline": "^1.2.1",
     "@tanstack/react-query": "^5.90.21",

--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -56,5 +56,10 @@
     "vite-plugin-pwa": "^1.2.0",
     "vitest": "^4.1.1",
     "workbox-window": "^7.4.0"
+  },
+  "overrides": {
+    "@codetrix-studio/capacitor-google-auth": {
+      "@capacitor/core": "$@capacitor/core"
+    }
   }
 }

--- a/Frontend/src/features/auth/components/LoginPage.tsx
+++ b/Frontend/src/features/auth/components/LoginPage.tsx
@@ -1,4 +1,6 @@
-import { useState } from "react"
+import { useState, useEffect } from "react"
+import { Capacitor } from "@capacitor/core"
+import { GoogleAuth } from "@codetrix-studio/capacitor-google-auth"
 import { loginWithGoogle } from "../services/authApi"
 import { useAuthStore } from "../../../store/authStore"
 import PrivacyPolicyModal from "../../../components/PrivacyPolicyModal"
@@ -26,18 +28,73 @@ declare global {
   }
 }
 
+const isNative = Capacitor.isNativePlatform()
+
 export default function LoginPage() {
   const setAuth = useAuthStore((state) => state.setAuth)
   const setGuest = useAuthStore((state) => state.setGuest)
   const [loginError, setLoginError] = useState<string | null>(null)
   const [privacyOpen, setPrivacyOpen] = useState(false)
 
+  // Initialize the native Google Auth plugin once on mount (no-op on web)
+  useEffect(() => {
+    if (isNative) {
+      GoogleAuth.initialize({
+        clientId: import.meta.env.VITE_GOOGLE_CLIENT_ID,
+        scopes: ["profile", "email"],
+        grantOfflineAccess: false,
+      })
+    }
+  }, [])
+
   const handleGuestContinue = () => {
     setGuest()
     window.location.href = '/'
   }
 
-  const handleGoogleLogin = () => {
+  const handleAuthError = (error: unknown) => {
+    console.error("Login failed", error)
+    if (error && typeof error === "object" && "code" in error) {
+      const code = (error as { code: string }).code
+      if (code === "ERR_NETWORK" || code === "ECONNABORTED") {
+        setLoginError("Couldn't reach the server. It may be starting up - please wait 30 seconds and try again.")
+        return
+      }
+    }
+    if (error && typeof error === "object" && "response" in error) {
+      const res = (error as { response: { status: number; data?: { detail?: string } } }).response
+      setLoginError(`Server error ${res.status}: ${res.data?.detail ?? "Unknown error"}`)
+    } else {
+      setLoginError("Sign-in failed. Please try again.")
+    }
+  }
+
+  const handleNativeGoogleLogin = async () => {
+    try {
+      const googleUser = await GoogleAuth.signIn()
+      const idToken = googleUser.authentication?.idToken
+      if (!idToken) {
+        setLoginError("Google sign-in did not return a token. Please try again.")
+        return
+      }
+      const result = await loginWithGoogle(idToken, "id_token")
+      setAuth(result.user, result.access_token, result.refresh_token)
+      window.location.href = '/'
+    } catch (error: unknown) {
+      // User cancelled sign-in - no error to show
+      if (
+        error &&
+        typeof error === "object" &&
+        "error" in error &&
+        (error as { error: string }).error === "popup_closed_by_user"
+      ) {
+        return
+      }
+      handleAuthError(error)
+    }
+  }
+
+  const handleWebGoogleLogin = () => {
     if (!window.google?.accounts?.oauth2) {
       setLoginError("Google sign-in isn't ready yet - please wait a moment and try again.")
       return
@@ -52,26 +109,20 @@ export default function LoginPage() {
           setAuth(result.user, result.access_token, result.refresh_token)
           window.location.href = '/'
         } catch (error: unknown) {
-          console.error("Login failed", error)
-          if (error && typeof error === "object" && "code" in error) {
-            const code = (error as { code: string }).code
-            // ERR_NETWORK = CORS block or server unreachable
-            // ECONNABORTED = axios request timeout
-            if (code === "ERR_NETWORK" || code === "ECONNABORTED") {
-              setLoginError("Couldn't reach the server. It may be starting up - please wait 30 seconds and try again.")
-              return
-            }
-          }
-          if (error && typeof error === "object" && "response" in error) {
-            const res = (error as { response: { status: number; data?: { detail?: string } } }).response
-            setLoginError(`Server error ${res.status}: ${res.data?.detail ?? "Unknown error"}`)
-          } else {
-            setLoginError("Sign-in failed. Please try again.")
-          }
+          handleAuthError(error)
         }
       },
     })
     client.requestAccessToken()
+  }
+
+  const handleGoogleLogin = () => {
+    setLoginError(null)
+    if (isNative) {
+      handleNativeGoogleLogin()
+    } else {
+      handleWebGoogleLogin()
+    }
   }
 
   return (

--- a/Frontend/src/features/auth/services/authApi.ts
+++ b/Frontend/src/features/auth/services/authApi.ts
@@ -10,8 +10,12 @@ interface LoginResponse {
   user: User
 }
 
-export async function loginWithGoogle(googleAccessToken: string): Promise<LoginResponse> {
-  const response = await apiClient.post(ENDPOINTS.AUTH.GOOGLE, { access_token: googleAccessToken })
+export async function loginWithGoogle(
+  token: string,
+  tokenType: "access_token" | "id_token" = "access_token",
+): Promise<LoginResponse> {
+  const payload = tokenType === "id_token" ? { id_token: token } : { access_token: token }
+  const response = await apiClient.post(ENDPOINTS.AUTH.GOOGLE, payload)
   return response.data
 }
 


### PR DESCRIPTION
## Problem

Google sign-in fails inside the Android APK (Capacitor WebView). The app loads and reaches the backend, but "Sign in with Google" never completes on mobile. It still works in a desktop browser.

**Root cause:** the login flow uses Google Identity Services (`window.google.accounts.oauth2.initTokenClient`), a pure web popup tied to the Web OAuth client. Google deliberately blocks OAuth sign-in inside embedded WebViews (`disallowed_useragent` / 403 policy, shown to users as "this browser or app may not be secure"). Capacitor renders the app in Android's WebView, so Google refuses the flow. This cannot be fixed with a Google Cloud Console setting alone because the request is rejected on the WebView user-agent before origins are evaluated.

## Fix

Native Google sign-in on mobile, web flow unchanged (Option 1 from the investigation).

### Frontend
- Add `@codetrix-studio/capacitor-google-auth`.
- Branch on `Capacitor.isNativePlatform()`:
  - **Native:** `GoogleAuth.signIn()` opens the Android native account picker and returns an `idToken`, which is sent to the backend.
  - **Web:** the existing GIS `access_token` popup flow, untouched.
- `loginWithGoogle()` sends `id_token` or `access_token` depending on the source.

### Backend
- `verify_google_id_token()` validates ID tokens via Google's `tokeninfo` endpoint and asserts the audience matches `GOOGLE_CLIENT_ID` (no new Python dependencies).
- `POST /auth/google` now accepts either `id_token` or `access_token`.

## Manual steps required before the APK will work

1. **Google Cloud Console:** create an OAuth client of type **Android** with package name `com.parkandgo.umn` and the signing keystore SHA-1 (debug keystore for testing). Keep the existing Web client ID as the plugin `serverClientId`.
2. Run `npx cap sync android` to register the plugin.
3. Rebuild the APK in Android Studio.

No Render backend env changes are needed: `GOOGLE_CLIENT_ID` is already used for audience validation.

## Validation
- Frontend `npm run build` / `npm run lint` / `npm run test`: no new errors or failures in the changed files (pre-existing failures in unrelated test files remain).
- Web sign-in path is code-unchanged.

## Acceptance criteria
- Tapping "Sign in with Google" in the installed APK opens the native account picker and authenticates against the Render backend.
- Desktop web sign-in continues to work unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
