### PR TITLE
feat: keep screen awake during navigation (Screen Wake Lock)

### DIFF
--- a/Frontend/src/app/routes.tsx
+++ b/Frontend/src/app/routes.tsx
@@ -11,14 +11,21 @@ import RememberParkingSpotModal from "../features/navigation/components/Remember
 import SettingsModal from "../features/profile/components/SettingsModal";
 import SuggestSpotModal from "../features/parking/components/SuggestSpotModal";
 import { useUIStore } from "../store/uiStore";
+import { useNavStore } from "../store/navStore";
 import { useActiveNavigation } from "../features/navigation/hooks/useActiveNavigation";
+import { useWakeLock } from "../hooks/useWakeLock";
 import { initializeParkingReminderScheduler } from "../features/navigation/services/parkingReminderScheduler";
 
 function AppShell() {
   const darkMode = useUIStore((s) => s.darkMode)
+  const isNavigating = useNavStore((s) => s.isNavigating)
 
   // Enable active navigation tracking (real-time updates, step advancement, auto-end)
   useActiveNavigation()
+
+  // Keep the screen awake for the whole trip while navigation is active.
+  // No-op on browsers without the Screen Wake Lock API.
+  useWakeLock(isNavigating)
 
   // Sync dark mode preference to <html> data-theme attribute
   useEffect(() => {

--- a/Frontend/src/hooks/__tests__/useWakeLock.test.tsx
+++ b/Frontend/src/hooks/__tests__/useWakeLock.test.tsx
@@ -1,0 +1,85 @@
+import { render, waitFor } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { useWakeLock } from "../useWakeLock"
+
+type MockSentinel = {
+  released: boolean
+  release: ReturnType<typeof vi.fn>
+}
+
+function makeSentinel(): MockSentinel {
+  const sentinel: MockSentinel = {
+    released: false,
+    release: vi.fn(async () => {
+      sentinel.released = true
+    }),
+  }
+  return sentinel
+}
+
+function HookHarness({ enabled }: { enabled: boolean }) {
+  useWakeLock(enabled)
+  return null
+}
+
+describe("useWakeLock", () => {
+  let sentinel: MockSentinel
+  let request: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    sentinel = makeSentinel()
+    request = vi.fn(async () => sentinel)
+    Object.defineProperty(navigator, "wakeLock", {
+      value: { request },
+      configurable: true,
+      writable: true,
+    })
+    // jsdom reports visibilityState as "visible" by default; make it writable
+    Object.defineProperty(document, "visibilityState", {
+      value: "visible",
+      configurable: true,
+      writable: true,
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("requests a screen wake lock when enabled", async () => {
+    render(<HookHarness enabled={true} />)
+    await waitFor(() => expect(request).toHaveBeenCalledWith("screen"))
+  })
+
+  it("does not request a lock when disabled", () => {
+    render(<HookHarness enabled={false} />)
+    expect(request).not.toHaveBeenCalled()
+  })
+
+  it("releases the wake lock on cleanup", async () => {
+    const { unmount } = render(<HookHarness enabled={true} />)
+    await waitFor(() => expect(request).toHaveBeenCalledTimes(1))
+    unmount()
+    await waitFor(() => expect(sentinel.release).toHaveBeenCalled())
+  })
+
+  it("re-acquires the lock when the page becomes visible again", async () => {
+    render(<HookHarness enabled={true} />)
+    await waitFor(() => expect(request).toHaveBeenCalledTimes(1))
+
+    // Simulate the browser auto-releasing the lock while backgrounded.
+    sentinel.released = true
+    document.dispatchEvent(new Event("visibilitychange"))
+
+    await waitFor(() => expect(request).toHaveBeenCalledTimes(2))
+  })
+
+  it("does nothing and does not throw when the API is unsupported", () => {
+    // Remove the API entirely so "wakeLock" in navigator is false.
+    delete (navigator as { wakeLock?: unknown }).wakeLock
+    expect("wakeLock" in navigator).toBe(false)
+    expect(() => render(<HookHarness enabled={true} />)).not.toThrow()
+    expect(request).not.toHaveBeenCalled()
+  })
+})

--- a/Frontend/src/hooks/index.ts
+++ b/Frontend/src/hooks/index.ts
@@ -3,3 +3,4 @@
 export * from "./useGeolocation"
 export * from "./useDebounce"
 export * from "./useMediaQuery"
+export * from "./useWakeLock"

--- a/Frontend/src/hooks/useWakeLock.ts
+++ b/Frontend/src/hooks/useWakeLock.ts
@@ -1,0 +1,66 @@
+/* Hook for keeping the device screen awake via the Screen Wake Lock API */
+
+import { useEffect, useRef } from "react";
+
+/**
+ * Keeps the device screen awake while `enabled` is true.
+ *
+ * Uses the Screen Wake Lock API (navigator.wakeLock.request("screen")).
+ * The browser automatically releases the lock when the page is hidden or
+ * backgrounded, so a visibilitychange handler re-acquires it once the
+ * document becomes visible again. This is what makes the lock feel
+ * persistent across app switches.
+ *
+ * Requirements and fallbacks:
+ * - Needs a secure context (HTTPS or localhost). Production runs on HTTPS.
+ * - Degrades to a no-op where the API is unsupported (e.g. older iOS
+ *   Safari). No crash, just no lock.
+ */
+export function useWakeLock(enabled: boolean) {
+  const sentinelRef = useRef<WakeLockSentinel | null>(null);
+
+  useEffect(() => {
+    if (!enabled) return;
+    if (!("wakeLock" in navigator)) return;
+
+    // Tracks whether this effect run has been cleaned up, so a lock that
+    // resolves after cleanup is released instead of leaking.
+    let cancelled = false;
+
+    const requestLock = async () => {
+      // Skip if we already hold an active lock (avoids duplicate sentinels
+      // when visibilitychange fires while a lock is still live).
+      if (sentinelRef.current && !sentinelRef.current.released) return;
+      try {
+        const sentinel = await navigator.wakeLock.request("screen");
+        if (cancelled) {
+          void sentinel.release();
+          return;
+        }
+        sentinelRef.current = sentinel;
+      } catch {
+        // request() rejects if the document is not visible or the browser
+        // refuses. Fail silently: this is a best-effort enhancement.
+      }
+    };
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "visible") {
+        void requestLock();
+      }
+    };
+
+    void requestLock();
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+
+    return () => {
+      cancelled = true;
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+      const sentinel = sentinelRef.current;
+      sentinelRef.current = null;
+      if (sentinel && !sentinel.released) {
+        void sentinel.release();
+      }
+    };
+  }, [enabled]);
+}


### PR DESCRIPTION
Closes #11

## Summary

Keeps the device screen awake during navigation so it does not auto-sleep mid-trip, matching the behavior of turn-by-turn navigation apps. Uses the [Screen Wake Lock API](https://developer.mozilla.org/en-US/docs/Web/API/Screen_Wake_Lock_API).

## Changes

- **New `Frontend/src/hooks/useWakeLock.ts`** - `useWakeLock(enabled)`:
  - Requests `navigator.wakeLock.request("screen")` when `enabled`, stores the `WakeLockSentinel`.
  - Releases the lock on cleanup / when disabled.
  - Re-acquires on `visibilitychange` when the document becomes visible again (browsers auto-release the lock when the tab is backgrounded, so this is what makes it feel persistent).
  - Guards `"wakeLock" in navigator` and wraps `request()` in try/catch, so unsupported browsers (e.g. older iOS Safari) are a silent no-op with no crash.
  - Skips duplicate requests while a live sentinel is held (`sentinel.released` check).
- **`Frontend/src/app/routes.tsx`** - activate in `AppShell` with `useWakeLock(isNavigating)` (from `navStore`), next to the existing `useActiveNavigation()`. The lock is held for the whole trip and released automatically when navigation ends.
- **`Frontend/src/hooks/index.ts`** - export the new hook.
- **`Frontend/src/hooks/__tests__/useWakeLock.test.tsx`** - 5 tests: requests when enabled, no request when disabled, releases on cleanup, re-acquires on visibility change, and no-op/no-throw when the API is unsupported.

## Acceptance criteria

- [x] While navigating, the screen does not auto-sleep on supported browsers.
- [x] The wake lock is released when navigation ends (or the feature is toggled off).
- [x] Backgrounding then returning to the app re-acquires the lock.
- [x] Unsupported browsers degrade gracefully with no errors.

## Notes

- Screen Wake Lock requires a secure context (HTTPS). Production is on Vercel (HTTPS) and localhost is treated as secure, so both are fine.
- The optional Settings > Preferences "Keep screen on" toggle from the issue was intentionally left out: it is marked optional and the default (on during navigation only) is fully covered here. Easy follow-up if wanted.

## Validation

- `npm run build`: passes.
- `npm run lint`: changed files are clean (pre-existing lint problems remain only in untouched files such as `useMediaQuery.ts`).
- `npm run test`: 164 pass / 1 skip. The single failing test (`recommendationApi.test.ts`) is pre-existing and unrelated, confirmed still failing with these changes stashed out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
